### PR TITLE
Add documentation for the tengu-backend-wgpu declarator and emitter crates

### DIFF
--- a/tengu-backend-wgpu/src/processor/declarator.rs
+++ b/tengu-backend-wgpu/src/processor/declarator.rs
@@ -1,6 +1,11 @@
-use std::collections::HashMap;
+//! This module defines the `Declarator` struct and associated functions for managing
+//! shader variable declarations in a WGPU-based tensor computation framework.
+//!
+//! The `Declarator` struct is used to create and manage storage variable declarations
+//! for tensors, which are then used in shader programs.
 
 use itertools::Itertools;
+use std::collections::HashMap;
 use tengu_backend::StorageType;
 use tengu_wgpu::BufferUsage;
 
@@ -9,23 +14,40 @@ use crate::tensor::Tensor;
 
 const GROUP: usize = 0;
 
+/// A struct for declaring shader storage variables.
 pub struct Declarator<'a> {
     declarations: HashMap<&'a str, String>,
 }
 
 impl Declarator<'_> {
+    /// Creates a new `Declarator`.
+    ///
+    /// # Returns
+    /// A new instance of `Declarator`.
     pub fn new() -> Self {
         Self {
             declarations: HashMap::new(),
         }
     }
 
+    /// Generates a header string containing all the declarations.
+    ///
+    /// # Returns
+    /// A `String` containing the header with all declarations.
     pub fn header(&self) -> String {
         self.declarations.values().join("\n")
     }
 }
 
+// NOTE: Processing interface
+
 impl<'a> Declarator<'a> {
+    /// Processes a variable by adding it to the list of tensor declarations.
+    /// not there yet.
+    ///
+    /// # Parameters
+    /// - `binding`: The binding index for the shader variable.
+    /// - `tensor`: The tensor to declare as a shader variable.
     pub fn var<T: StorageType>(&mut self, binding: usize, tensor: &'a Tensor<T>) {
         self.declarations
             .entry(tensor.label())
@@ -33,6 +55,14 @@ impl<'a> Declarator<'a> {
     }
 }
 
+/// Generates a declaration string for a tensor.
+///
+/// # Parameters
+/// - `binding`: The binding index for the shader variable.
+/// - `tensor`: The tensor to declare as a shader variable.
+///
+/// # Returns
+/// A `String` containing the declaration for the tensor.
 fn declaration<T: StorageType>(binding: usize, tensor: &Tensor<T>) -> String {
     let label = tensor.label();
     let access = access(tensor.buffer().usage());
@@ -40,6 +70,13 @@ fn declaration<T: StorageType>(binding: usize, tensor: &Tensor<T>) -> String {
     format!("@group({GROUP}) @binding({binding}) var<storage, {access}> {label}: array<{ty}>;")
 }
 
+/// Determines the access type for a buffer based on its usage.
+///
+/// # Parameters
+/// - `usage`: The buffer usage type.
+///
+/// # Returns
+/// A static string representing the access type.
 fn access(usage: BufferUsage) -> &'static str {
     match usage {
         BufferUsage::Read => "read",
@@ -49,9 +86,13 @@ fn access(usage: BufferUsage) -> &'static str {
     }
 }
 
-// Default implementation
+// NOTE: Default implementation
 
 impl Default for Declarator<'_> {
+    /// Creates a new `Declarator` using the default implementation.
+    ///
+    /// # Returns
+    /// A new instance of `Declarator`.
     fn default() -> Self {
         Declarator::new()
     }

--- a/tengu-backend-wgpu/src/processor/emitter.rs
+++ b/tengu-backend-wgpu/src/processor/emitter.rs
@@ -1,3 +1,9 @@
+//! This module defines the `Emitter` struct and associated functions for generating
+//! shader code in a WGPU-based tensor computation framework.
+//!
+//! The `Emitter` struct is used to create and manage expressions and statements
+//! for use in compute shaders, in the tensor body, not in the variable declaration part.
+
 use indoc::formatdoc;
 use itertools::Itertools;
 use tengu_backend::StorageType;
@@ -9,13 +15,22 @@ pub struct Emitter {
     expression: String,
 }
 
+/// A struct for generating shader code expressions and statements.
 impl Emitter {
+    /// Creates a new `Emitter`.
+    ///
+    /// # Returns
+    /// A new instance of `Emitter`.
     pub fn new() -> Self {
         Self {
             expression: String::new(),
         }
     }
 
+    /// Generates the body of the compute shader.
+    ///
+    /// # Returns
+    /// A `String` containing the shader body with all expressions.
     pub fn body(&self) -> String {
         formatdoc!(
             r"
@@ -30,41 +45,96 @@ impl Emitter {
     }
 }
 
-// Processing interface
+// NOTE: Processing interface
 
 impl Emitter {
+    /// Returns a string representation of the tensor variable.
+    ///
+    /// # Parameters
+    /// - `tensor`: The tensor to declare as a variable.
+    ///
+    /// # Returns
+    /// A `String` representing the variable declaration.
     pub fn var<T: StorageType>(&mut self, tensor: &Tensor<T>) -> String {
         format!("{}[idx]", tensor.label())
     }
 
+    /// Return a string representation of a scalar literal.
+    ///
+    /// # Parameters
+    /// - `value`: The scalar value.
+    ///
+    /// # Returns
+    /// A `String` representing the scalar value.
     pub fn scalar<T: StorageType>(&mut self, value: T) -> String {
         value.to_string()
     }
 
+    /// Returns a string representation of unary function expression.
+    ///
+    /// # Parameters
+    /// - `inner`: The inner expression.
+    /// - `symbol`: The unary function symbol.
+    ///
+    /// # Returns
+    /// A `String` representing the unary function application.
     pub fn unary_fn(&mut self, inner: String, symbol: &str) -> String {
         format!("{symbol}({inner})")
     }
 
+    /// Returns a string representation of a binary expression.
+    ///
+    /// # Parameters
+    /// - `lhs`: The left-hand side expression.
+    /// - `rhs`: The right-hand side expression.
+    /// - `symbol`: The binary operator symbol.
+    ///
+    /// # Returns
+    /// A `String` representing the binary operation.
     pub fn binary(&mut self, lhs: String, rhs: String, symbol: &str) -> String {
         format!("({lhs} {symbol} {rhs})")
     }
 
+    /// Returns a string representation of a cast expression.
+    ///
+    /// # Parameters
+    /// - `inner`: The inner expression.
+    /// - `ty`: The target type.
+    ///
+    /// # Returns
+    /// A `String` representing the casted expression.
     pub fn cast(&mut self, inner: String, ty: &str) -> String {
         format!("{ty}({inner})")
     }
 
+    /// Return a string representation of a statement.
+    ///
+    /// # Parameters
+    /// - `out`: The output variable.
+    /// - `expr`: The expression to assign to the output.
+    ///
+    /// # Returns
+    /// A `String` representing the statement.
     pub fn statement(&mut self, out: String, expr: String) -> String {
         format!("{out} = {expr};")
     }
 
+    /// Processes a block of expressions. The final representation is stored inside the emitter.
+    ///
+    /// # Parameters
+    /// - `exprs`: An iterator over expressions to include in the block.
     pub fn block(&mut self, exprs: impl Iterator<Item = String>) {
         self.expression = exprs.into_iter().join("\n    ");
     }
 }
 
-// Default implementation
+// NOTE: Default implementation
 
 impl Default for Emitter {
+    /// Creates a new `Emitter` using the default implementation.
+    ///
+    /// # Returns
+    /// A new instance of `Emitter`.
     fn default() -> Self {
         Emitter::new()
     }


### PR DESCRIPTION
# Problem Context
We forgot documentation for two submodules. This PR addresses it.

## Changes
Added documentation comments for `emitter` and `declarator` submodule in the `tensor-backend-wgpu` crate.